### PR TITLE
Bug 6900 - Added UsePythonVersion step to jinja templates

### DIFF
--- a/de_templates/ingest/Ingest_SourceType_SourceName/de-ingest-ado-pipeline.yml.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/de-ingest-ado-pipeline.yml.jinja
@@ -76,6 +76,12 @@ stages:
           - template: ../../../build/azDevOps/templates/air-infrastructure-data-setup.yml
             parameters:
               TaskctlVersion: {% raw %}${{ variables.TaskctlVersion }}{% endraw %}
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: $(pythonVersion)
+              githubToken: $(github_token)
+              addToPath: true
+            displayName: Set Python Version
           - script: pip install --upgrade pre-commit tomli
             displayName: Install pre-commit
           - bash: |

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/de-ingest-ado-pipeline.yml.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/de-ingest-ado-pipeline.yml.jinja
@@ -76,6 +76,12 @@ stages:
           - template: ../../../build/azDevOps/templates/air-infrastructure-data-setup.yml
             parameters:
               TaskctlVersion: {% raw %}${{ variables.TaskctlVersion }}{% endraw %}
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: $(pythonVersion)
+              githubToken: $(github_token)
+              addToPath: true
+            displayName: Set Python Version
           - script: pip install --upgrade pre-commit tomli
             displayName: Install pre-commit
           - bash: |


### PR DESCRIPTION
#### 📲 What

Set the python version before installing and running python packages

#### 🤔 Why

Without this it will fail when running precommit checks

#### 🛠 How

Added UsePythonVersion step to jinja templates

#### 👀 Evidence
Before:
![image](https://github.com/Ensono/stacks-azure-data/assets/47520690/219958ad-889e-4c06-b094-97f395429a85)
After:
![image](https://github.com/Ensono/stacks-azure-data/assets/47520690/261d5bd6-4b8e-41af-b028-0e68734811f9)

Create data workload using templates as you can see the UsePythonVersion has been added
![image](https://github.com/Ensono/stacks-azure-data/assets/47520690/d99aa117-1250-4acb-b984-b12a602bb842)
