### PR TITLE
6905 - Missing parameters in template DQ pipeline

### DIFF
--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/data_factory/pipelines/ARM_IngestTemplate.json.jinja
@@ -271,7 +271,10 @@
                         "userProperties": [],
                         "typeProperties": {
                             "pythonFile": "dbfs:/FileStore/scripts/{{ pipeline_name }}/ingest_dq.py",
-                            "parameters": [],
+                            "parameters": [
+                                "@variables('run_id')",
+                                "@string(variables('automated_test_flag'))"
+                            ],
                             "libraries": [
                                 {
                                     "whl": "dbfs:/FileStore/jars/datastacks-latest-py3-none-any.whl"


### PR DESCRIPTION
#### 📲 What

Adding missing data quality job parameters to template data quality pipeline

#### 🤔 Why

For the data quality job to run in databricks, we need to pass in two parameters from the ADF pipeline. When the work to add these was completed, this template was missed. 

#### ✅ Acceptance criteria Checklist

- [x] Code peer reviewed?
- [x] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [x] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
