### PR TITLE
Bug/6972 fix GitHub releases

### DIFF
--- a/build/azDevOps/azure/air-infrastructure-data-vars.yml
+++ b/build/azDevOps/azure/air-infrastructure-data-vars.yml
@@ -27,5 +27,3 @@ variables:
   # GitHub infomration
   - name: create_release
     value: true
-  - name: github_org
-    value: $(company)

--- a/build/azDevOps/azure/air-infrastructure-data.yml
+++ b/build/azDevOps/azure/air-infrastructure-data.yml
@@ -321,7 +321,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/build/azDevOps/azure/network/air-infrastructure-data-network-vars.yml
+++ b/build/azDevOps/azure/network/air-infrastructure-data-network-vars.yml
@@ -20,5 +20,3 @@ variables:
   # GitHub infomration
   - name: create_release
     value: true
-  - name: github_org
-    value: $(company)

--- a/de_build/job-pipeline-vars.yml
+++ b/de_build/job-pipeline-vars.yml
@@ -14,5 +14,3 @@ variables:
   # GitHub information
   - name: create_release
     value: true
-  - name: github_org
-    value: $(company)

--- a/de_templates/ingest/Ingest_SourceType_SourceName/de-ingest-ado-pipeline.yml.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName/de-ingest-ado-pipeline.yml.jinja
@@ -391,7 +391,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/de_templates/ingest/Ingest_SourceType_SourceName_DQ/de-ingest-ado-pipeline.yml.jinja
+++ b/de_templates/ingest/Ingest_SourceType_SourceName_DQ/de-ingest-ado-pipeline.yml.jinja
@@ -415,7 +415,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/de_workloads/data_processing/silver_movies_example/silver_movies_example.yml
+++ b/de_workloads/data_processing/silver_movies_example/silver_movies_example.yml
@@ -414,7 +414,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/de_workloads/ingest/Ingest_AzureSql_Example/de-ingest-azuresql-example.yml
+++ b/de_workloads/ingest/Ingest_AzureSql_Example/de-ingest-azuresql-example.yml
@@ -416,7 +416,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/de_workloads/shared_resources/de-shared-resources.yml
+++ b/de_workloads/shared_resources/de-shared-resources.yml
@@ -441,7 +441,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"

--- a/docs/workloads/azure/data/requirements_data_azure.md
+++ b/docs/workloads/azure/data/requirements_data_azure.md
@@ -121,10 +121,11 @@ Deployment', referring to variables required after the fundamental infrastructur
 </details>
 
 ### Azure Pipelines Service Connections
+
 Service Connections are used in Azure DevOps Pipelines to connect to external services, like Azure and GitHub.
 You must create the following Service Connections:
 
 | Name                  | When Needed   | Description                                           |
 |-----------------------|---------------|-------------------------------------------------------|
-| Stacks.Pipeline.Builds | Project start | The Service Connection to Azure |
-| GitHubReleases | Project start | The Service Connection to Github for releases |
+| Stacks.Pipeline.Builds | Project start | The Service Connection to Azure. The service principal or managed identity that is used to create the connection must have contributor access to the Azure Subscription. |
+| GitHubReleases | Project start | The Service Connection to Github for releases. The access token that is used to create the connection must have read/write access to the GitHub repository. |

--- a/pysparkle/pysparkle-pipeline.yml
+++ b/pysparkle/pysparkle-pipeline.yml
@@ -274,7 +274,7 @@ stages:
             displayName: Create GitHub Release
             inputs:
               gitHubConnection: $(github_release_service_connection)
-              repositoryName: $(github_org)/$(self_repo)
+              repositoryName: '$(Build.Repository.Name)'
               tag: v${newVersion}
               releaseNotesSource: "inline"
               releaseNotesInline: "$(major).$(minor).$(revision)"


### PR DESCRIPTION
#### 📲 What

Fix issue with github release by providing the correct repository name that doesn't rely on the company name and updated the documentation

#### 🤔 Why

The github release step fails when the company name is different from the github organisation name

#### 🛠 How

$(Build.Repository.Name) is being used instead of company name. Updated all places where we are creating a release. Removed github_org variable which is now not being used.

Documentation updated in https://github.com/Ensono/amido.github.io/pull/428 and in this repo.

#### 👀 Evidence
Pipeline:
![image](https://github.com/Ensono/stacks-azure-data/assets/47520690/4b24bec8-296d-459c-a846-eca08cd9bc6c)
Documentation:
![image](https://github.com/Ensono/stacks-azure-data/assets/47520690/36e1f3e7-9457-4170-9b5f-ab33e8d78f0c)
