### PR TITLE
Bug/7032-remove hardcoded hub name

### DIFF
--- a/build/azDevOps/azure/network/air-infrastructure-data-network.yml
+++ b/build/azDevOps/azure/network/air-infrastructure-data-network.yml
@@ -80,7 +80,7 @@ stages:
                   displayName: "Taskctl: Infrastructure"
                   inputs:
                     targetType: inline
-                    script: taskctl infrastructurePlan
+                    script: taskctl infrastructure
                     informationPreference: continue
                   env:
                     ENV_NAME: $(Environment.ShortName)

--- a/build/azDevOps/azure/network/air-infrastructure-data-network.yml
+++ b/build/azDevOps/azure/network/air-infrastructure-data-network.yml
@@ -80,7 +80,7 @@ stages:
                   displayName: "Taskctl: Infrastructure"
                   inputs:
                     targetType: inline
-                    script: taskctl infrastructure
+                    script: taskctl infrastructurePlan
                     informationPreference: continue
                   env:
                     ENV_NAME: $(Environment.ShortName)

--- a/deploy/azure/networking/main.tf
+++ b/deploy/azure/networking/main.tf
@@ -1,3 +1,7 @@
+locals {
+  # Get the hub network name which will be used later to deploy the vmss into it
+  hub_network_name = [for network in var.network_details : network.name if network.is_hub == true][0]
+}
 
 # Naming convention
 module "default_label" {
@@ -27,10 +31,10 @@ module "vmss" {
   count                        = var.enable_private_networks ? 1 : 0
   source                       = "git::https://github.com/amido/stacks-terraform//azurerm/modules/azurerm-vmss?ref=update-agent-version"
   vmss_name                    = module.default_label.id
-  vmss_resource_group_name     = module.networking.vnets["amido-stacks-euw-de-hub"].vnet_resource_group_name
+  vmss_resource_group_name     = module.networking.vnets[local.hub_network_name].vnet_resource_group_name
   vmss_resource_group_location = var.resource_group_location
   vnet_name                    = module.networking.hub_net_name
-  vnet_resource_group          = module.networking.vnets["amido-stacks-euw-de-hub"].vnet_resource_group_name
+  vnet_resource_group          = module.networking.vnets[local.hub_network_name].vnet_resource_group_name
   subnet_name                  = var.vmss_subnet_name
   vmss_instances               = var.vmss_instances
   vmss_admin_username          = var.vmss_admin_username

--- a/deploy/azure/networking/main.tf
+++ b/deploy/azure/networking/main.tf
@@ -25,7 +25,7 @@ module "networking" {
 
 module "vmss" {
   count                        = var.enable_private_networks ? 1 : 0
-  source                       = "git::https://github.com/amido/stacks-terraform//azurerm/modules/azurerm-vmss"
+  source                       = "git::https://github.com/amido/stacks-terraform//azurerm/modules/azurerm-vmss?ref=update-agent-version"
   vmss_name                    = module.default_label.id
   vmss_resource_group_name     = module.networking.vnets["amido-stacks-euw-de-hub"].vnet_resource_group_name
   vmss_resource_group_location = var.resource_group_location

--- a/deploy/azure/networking/vars.tf
+++ b/deploy/azure/networking/vars.tf
@@ -273,7 +273,7 @@ variable "dns_zone_name" {
 ############################################
 
 variable "vmss_instances" {
-  default     = 1
+  default     = 2
   type        = number
   description = "Sets the default number of VM instances running in the VMSS."
 }

--- a/deploy/azure/networking/vars.tf
+++ b/deploy/azure/networking/vars.tf
@@ -273,7 +273,7 @@ variable "dns_zone_name" {
 ############################################
 
 variable "vmss_instances" {
-  default     = 2
+  default     = 1
   type        = number
   description = "Sets the default number of VM instances running in the VMSS."
 }

--- a/deploy/azure/networking/vars.tf
+++ b/deploy/azure/networking/vars.tf
@@ -279,7 +279,7 @@ variable "vmss_instances" {
 }
 
 variable "vmss_admin_username" {
-  default     = "adminuser"
+  default     = "rishi"
   type        = string
   description = "Sets the admin user name. This is used if remote access is required to a VM instance."
 }

--- a/deploy/azure/networking/vars.tf
+++ b/deploy/azure/networking/vars.tf
@@ -279,7 +279,7 @@ variable "vmss_instances" {
 }
 
 variable "vmss_admin_username" {
-  default     = "rishi"
+  default     = "adminuser"
   type        = string
   description = "Sets the admin user name. This is used if remote access is required to a VM instance."
 }

--- a/deploy/azure/networking/vars.tf
+++ b/deploy/azure/networking/vars.tf
@@ -5,19 +5,17 @@
 variable "name_company" {
   description = "Company Name - should/will be used in conventional resource naming"
   type        = string
-  default     = "amido"
 }
 
 variable "name_project" {
   description = "Project Name - should/will be used in conventional resource naming"
   type        = string
-  default     = "stacks"
 }
 
 variable "name_component" {
   description = "Component Name - should/will be used in conventional resource naming. Typically this will be a logical name for this part of the system i.e. `API` || `middleware` or more generic like `Billing`"
   type        = string
-  default     = "de"
+  default     = "data"
 }
 
 
@@ -40,7 +38,7 @@ variable "tags" {
 
 variable "resource_group_location" {
   type    = string
-  default = "westeurope"
+  default = "uksouth"
 }
 
 
@@ -66,7 +64,7 @@ variable "location_name_map" {
 ############################################
 
 variable "enable_private_networks" {
-  default     = true
+  default     = false
   type        = bool
   description = "Enable Private Networking for Secure Data Platform."
 }
@@ -75,7 +73,7 @@ variable "enable_private_networks" {
 variable "link_dns_network" {
   description = "weather link DNS with vnets"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "network_details" {
@@ -281,8 +279,7 @@ variable "vmss_instances" {
 }
 
 variable "vmss_admin_username" {
-  #default     = "adminuser"
-  default     = "rishi"
+  default     = "adminuser"
   type        = string
   description = "Sets the admin user name. This is used if remote access is required to a VM instance."
 }


### PR DESCRIPTION
#### 📲 What

Remove hardcoded hub name and grab the name by selecting the network which has is_hub = true

Updated the variables so they are inline with what has been deployed. 

Also updated taskctl.yaml so terraformPlan only runs a terraform plan

#### 🤔 Why

A client may not have a hub with that name

#### 🛠 How

#### 👀 Evidence

