### PR TITLE
Fix: 7091 - Datastacks import error

### DIFF
--- a/datastacks/datastacks/cli/datastacks_cli.py
+++ b/datastacks/datastacks/cli/datastacks_cli.py
@@ -10,8 +10,8 @@ from click_loglevel import LogLevel
 from datastacks.constants import CONFIG_CONTAINER_NAME
 from datastacks.pyspark.data_quality.main import data_quality_main
 from datastacks.logger import setup_logger
-from datastacks.cli.utils import generate_pipeline
-from datastacks.cli.config import INGEST_TEMPLATE_FOLDER
+from datastacks.cli.utils import validate_yaml_config, generate_pipeline
+from datastacks.cli.config import IngestWorkloadConfigModel, ProcessingWorkloadConfigModel
 
 
 @click.group()
@@ -40,7 +40,23 @@ def generate():
 )
 def ingest(config, data_quality):
     """Generate new data ingest workload."""
-    generate_pipeline(config, data_quality, INGEST_TEMPLATE_FOLDER, "Ingest")
+    validated_config = validate_yaml_config(config, IngestWorkloadConfigModel)
+    generate_pipeline(validated_config, data_quality)
+
+
+@generate.command()
+@click.help_option("-h", "--help")
+@click.option("--config", "-c", type=str, help="Absolute path to config file on local machine")
+@click.option(
+    "--data-quality/--no-data-quality",
+    "-dq/-ndq",
+    default=False,
+    help="Flag to determine whether to include data quality in template",
+)
+def processing(config, data_quality):
+    """Generate new data processing example workload."""
+    validated_config = validate_yaml_config(config, ProcessingWorkloadConfigModel)
+    generate_pipeline(validated_config, data_quality)
 
 
 @cli.command()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pydantic = "^1.10.12"
 delta-spark = "^2.4.0"
 
 [tool.poetry.scripts]
-datastacks = "datastacks.cli:cli"
+datastacks = "datastacks.cli.datastacks_cli:cli"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"


### PR DESCRIPTION
#### 📲 What

Fix to Datastacks CLI - see https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/7091

#### 🤔 Why

Datastacks commands were failing.

#### 🛠 How

The file `datastacks_cli.py` was moved in the refactor (https://github.com/Ensono/stacks-azure-data/pull/195), but during this move it was updated with an older version of the code. This file is now reverted to what should have been the latest version.

#### 👀 Evidence

Datastacks commands now running successfully:
![image](https://github.com/Ensono/stacks-azure-data/assets/108685738/b4525962-4d09-4342-8fef-e8bfe7bf06ff)


#### 🕵️ How to test

Follow datastacks documentation to setup environment, and run datastacks commands to test.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
